### PR TITLE
updated ruby install for Mac

### DIFF
--- a/_docs/01_software/ruby.md
+++ b/_docs/01_software/ruby.md
@@ -10,13 +10,13 @@ section_order: 3
 
 ## 3. Install Ruby
 
-[Ruby](https://www.ruby-lang.org/en/){:target="_blank" rel="noopener"} is a programming language popular with web applications. 
+[Ruby](https://www.ruby-lang.org/en/){:target="_blank" rel="noopener"} is a programming language popular with web applications.
 **_You do not need to know anything about Ruby_** to use CollectionBuilder, but you do need it to run Jekyll on your system!
 
 Jekyll requires a Ruby version that is greater than 2.4.0.
 
 {% capture win-ruby %}
-Use [RubyInstaller for Windows](https://rubyinstaller.org/){:target="_blank" rel="noopener"}. 
+Use [RubyInstaller for Windows](https://rubyinstaller.org/){:target="_blank" rel="noopener"}.
 
 - First, [download](https://rubyinstaller.org/downloads/){:target="_blank" rel="noopener"} the suggested stable version "WITH DEVKIT" (as of this writing, Ruby+Devkit 2.6.X (x64)) and double click to install. Use the install defaults, but make sure "Add Ruby executables to your PATH" is checked. On the final step, ensure the box to start the MSYS2 DevKit is checked.
 
@@ -29,8 +29,8 @@ Use [RubyInstaller for Windows](https://rubyinstaller.org/){:target="_blank" rel
 {% capture mac-ruby %}
 Installing Ruby on Mac can be difficult, but don't be deterred! If the method below doesn't work for you check out [How to Install Ruby on a Mac](https://lib-static.github.io/howto/howtos/installrubymac.html){:target="_blank" rel="noopener"} for more detail and other options.
 
-OS X has a version of Ruby installed by default, but recommended practice is to set up a separate Ruby development environment. 
-To do this, follow the instructions below, which outline the steps to install Ruby using [rbenv](https://github.com/rbenv/rbenv){:target="_blank" rel="noopener"}. 
+OS X has a version of Ruby installed by default, but recommended practice is to set up a separate Ruby development environment.
+To do this, follow the instructions below, which outline the steps to install Ruby using [rbenv](https://github.com/rbenv/rbenv){:target="_blank" rel="noopener"}.
 
 #### Get the Xcode Command Line Tools First
 
@@ -49,32 +49,43 @@ To do this, follow the instructions below, which outline the steps to install Ru
 
 2. **Install rbenv**
     - Copy and paste the command `brew install rbenv` into your terminal prompt and press `Enter`. This installation might take a while.
-    - Once rbenv has been installed, copy and paste `rbenv init` into the terminal prompt and press `Enter`. 
-    - The program will ask you to edit your bash profile. To do this, follow these instructions:
-        - Open your bash profile with the terminal's text editor, nano, by copying and pasting  `nano ~/.bash_profile` into the terminal prompt and pressing `Enter`. 
-        - Your terminal should switch to a nano text editor screen that includes a path to .bash_profile at the top. 
-        - Use the down arrow on your keyboard to move to the end of the text file.
-        - Paste `eval "$(rbenv init -)"` at the end of the profile's text.
-        - Press `Control` + `x` to exit and save the profile. You'll see a message at the bottom of your screen asking whether you want to save the profile.
-        - Press the `y` key on your keyboard to specify yes, you want to save.
-        - Press `Enter` to finish saving the file and exit nano.
+    - Once rbenv has been installed, copy and paste `rbenv init` into the terminal prompt and press `Enter`.
+    - To complete the installation you will need to modify two configuration files:
+      - Open your zsh environment file with the terminal's text editor, nano, by copying and pasting `nano ~/.zshenv` into the terminal prompt and pressing `Enter`.
+      - Your terminal should switch to a nano text editor screen that includes a path to .zshenv at the top.
+      - Use the down arrow on your keyboard to move to the end of the text file.
+      - Paste `export PATH="$HOME/.rbenv/bin:$PATH"` at the end of the file.
+      - Press `Control` + `x` to exit and save the profile. You'll see a message at the bottom of your screen asking whether you want to save the file.
+      - Press the `y` key on your keyboard to specify yes, you want to save.
+      - Press `Enter` to finish saving the file and exit nano.
+      - Open your zsh configuration file with the terminal's text editor, nano, by copying and pasting `nano ~/.zshrc` into the terminal prompt and pressing `Enter`.
+      - Your terminal should switch to a nano text editor screen that includes a path to .zshrc at the top.
+      - Use the down arrow on your keyboard to move to the end of the text file.
+      - Paste the following two lines at the end of the file
+      ```
+      source $HOME/.zshenv
+      eval “$(rbenv init – zsh)"
+      ```
+      - Press `Control` + `x` to exit and save the file. You'll see a message at the bottom of your screen asking whether you want to save the file.
+      - Press the `y` key on your keyboard to specify yes, you want to save.
+      - Press `Enter` to finish saving the file and exit nano.
 
 3. **Install Ruby**
-    - Back in your terminal, install the latest version of ruby by copy/pasting or writing, `rbenv install 2.7.1` and pressing `Enter`. 
+    - Back in your terminal, install the latest version of ruby by copy/pasting or writing, `rbenv install 2.7.1` and pressing `Enter`.
 
     {:.alert .alert-warning .my-3}
     Note: 2.7.1 is the latest solid version as of this writing; if you are reading this past August 2020, you may need to check the "Stable Releases" section on [the download Ruby page](https://www.ruby-lang.org/en/downloads/){:target="_blank" rel="noopener"} and install the latest stable version.
 
-    - Now let's set that version as your global Ruby version by entering `rbenv global 2.7.1` into the terminal prompt and pressing `Enter`. 
+    - Now let's set that version as your global Ruby version by entering `rbenv global 2.7.1` into the terminal prompt and pressing `Enter`.
     - Finally, we're going to rehash, just to be safe: copy and paste the command `rbenv rehash` into your prompt and pressing `Enter`.
-    - Now let's see if that worked. 
+    - Now let's see if that worked.
         - Quit your terminal by right clicking (`Control + click`) its icon in your applications menu, and selecting `Quit` from the options that appear.
         - Then reopen your terminal by clicking `Command (⌘) + Spacebar`, typing `terminal` into the spotlight box that appears, and pressing `Enter`.
         - Type `ruby -v` into the terminal prompt, and press `Enter`.
         - If your terminal indicates that you have Ruby 2.7.0 or higher installed, you've done it!
 
 {:.alert .alert-danger}
-If this installation did not work, see our more detailed guide, [How to Install Ruby on a Mac](https://lib-static.github.io/howto/howtos/installrubymac.html){:target="_blank" rel="noopener"}, check out the [Jekyll install on mac docs](https://jekyllrb.com/docs/installation/macos/), or try Googling any error message or other hindrance you encountered. 
+If this installation did not work, see our more detailed guide, [How to Install Ruby on a Mac](https://lib-static.github.io/howto/howtos/installrubymac.html){:target="_blank" rel="noopener"}, check out the [Jekyll install on mac docs](https://jekyllrb.com/docs/installation/macos/), or try Googling any error message or other hindrance you encountered.
 {% endcapture %}
 {% include bootstrap/card.md text=mac-ruby header="Ruby on Mac" %}
 


### PR DESCRIPTION
As of Catalina default shell switched to zsh.  Steps reflect how to setup rbenv with zsh. I drew heavily from:  https://programmingzen.com/installing-rbenv-on-zsh-on-macos/